### PR TITLE
Fix sc_logic coverage

### DIFF
--- a/src/sysc/tracing/sc_coverage_trace.cpp
+++ b/src/sysc/tracing/sc_coverage_trace.cpp
@@ -162,14 +162,16 @@ namespace sc_core {
         std::exit(EXIT_FAILURE);
       }
 
-      bucketPerVal |= (numBits <= LogMaxNumBuckets);
-      hasSpecialZeroBucket = SpecialZeroBucketOK && !bucketPerVal;
+      if(!std::is_same<sc_dt::sc_logic, T>::value && !std::is_same<sc_dt::sc_bit, T>::value) {
+        bucketPerVal |= (numBits <= LogMaxNumBuckets);
+        hasSpecialZeroBucket = SpecialZeroBucketOK && !bucketPerVal;
 
-      numBuckets    = bucketPerVal ? (1 << numBits) : (MaxNumBuckets + hasSpecialZeroBucket);
-      logNumBuckets = logB2(numBuckets - hasSpecialZeroBucket);
+        numBuckets    = bucketPerVal ? (1 << numBits) : (MaxNumBuckets + hasSpecialZeroBucket);
+        logNumBuckets = logB2(numBuckets - hasSpecialZeroBucket);
 
-      for(std::size_t i = 0; i < numBuckets; ++i) {
-        buckets.emplace_back();
+        for(std::size_t i = 0; i < numBuckets; ++i) {
+          buckets.emplace_back();
+        }
       }
       lastVal = curVal;
     }

--- a/src/sysc/tracing/sc_coverage_trace.h
+++ b/src/sysc/tracing/sc_coverage_trace.h
@@ -8,7 +8,11 @@
 namespace sc_core {
   class cover_info_base {
    public:
-    cover_info_base(const std::string& name) : name(name) {}
+    cover_info_base(const std::string& name) : name(name) {
+      if(name.empty()) {
+        SC_REPORT_FATAL(SC_ID_TRACING_EMPTY_NAME_, "Attempting to cover object with no name");
+      }
+    }
     virtual std::int32_t getCoverage() const            = 0;
     virtual std::int32_t getNumBuckets() const          = 0;
     virtual std::int32_t getBucket(std::size_t i) const = 0;

--- a/src/sysc/tracing/sc_tracing_ids.h
+++ b/src/sysc/tracing/sc_tracing_ids.h
@@ -65,6 +65,8 @@ SC_DEFINE_MESSAGE( SC_ID_TRACING_ALREADY_INITIALIZED_,  720,
                    "sc_trace_file already initialized" )
 SC_DEFINE_MESSAGE( SC_ID_TRACING_DUPLICATE_OBJECT_,     721,
                    "object already traced" )
+SC_DEFINE_MESSAGE( SC_ID_TRACING_EMPTY_NAME_,           722,
+                   "empty name" )
 
 
 


### PR DESCRIPTION
- Fixes `sc_logic` & `sc_bit` buckets, which were previously being doubly-initialized
- Errors out if empty name is given for a coverage object